### PR TITLE
Escape html

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ assert(stringify('foo') === '"foo"');
 assert(stringify('foo\u2028bar\u2029baz') === '"foo\\u2028bar\\u2029baz"');
 assert(stringify(new Date('2014-12-19T03:42:00.000Z')) === 'new Date("2014-12-19T03:42:00.000Z")');
 assert(stringify({foo: 'bar'}) === '{"foo":"bar"}');
+assert(stringify(undefined) === 'undefined');
+assert(stringify(null) === 'null');
+assert(
+  stringify({val: "</script><script>alert('bad actor')</script>"}) ===
+  '{"val":"\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003Ealert(\'bad actor\')\\u003C\\u002Fscript\\u003E"}'
+);
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -10,5 +10,8 @@ function stringify(obj) {
   }
   return JSON.stringify(obj)
              .replace(/\u2028/g, '\\u2028')
-             .replace(/\u2029/g, '\\u2029');
+             .replace(/\u2029/g, '\\u2029')
+             .replace(/</g, '\\u003C')
+             .replace(/>/g, '\\u003E')
+             .replace(/\//g, '\\u002F');
 }

--- a/test/index.js
+++ b/test/index.js
@@ -9,5 +9,9 @@ assert(stringify(new Date('2014-12-19T03:42:00.000Z')) === 'new Date("2014-12-19
 assert(stringify({foo: 'bar'}) === '{"foo":"bar"}');
 assert(stringify(undefined) === 'undefined');
 assert(stringify(null) === 'null');
+assert(
+  stringify({val: "</script><script>alert('bad actor')</script>"}) ===
+  '{"val":"\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003Ealert(\'bad actor\')\\u003C\\u002Fscript\\u003E"}'
+);
 
 console.log('tests passed');


### PR DESCRIPTION
This change will make js-stringify safe to use on un-trusted input in inline scripts within HTML
