### PR TITLE
Allow pretty-printing JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ assert(stringify('foo') === '"foo"');
 assert(stringify('foo\u2028bar\u2029baz') === '"foo\\u2028bar\\u2029baz"');
 assert(stringify(new Date('2014-12-19T03:42:00.000Z')) === 'new Date("2014-12-19T03:42:00.000Z")');
 assert(stringify({foo: 'bar'}) === '{"foo":"bar"}');
+assert(stringify({foo: 'bar'}, 4) === '{\n    "foo": "bar"\n}');
+assert(stringify({foo: 'bar'}, '\t') === '{\n\t"foo": "bar"\n}');
 assert(stringify(undefined) === 'undefined');
 assert(stringify(null) === 'null');
 assert(

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
 module.exports = stringify;
-function stringify(obj) {
+function stringify(obj, indentation) {
   if (obj instanceof Date) {
     return 'new Date(' + stringify(obj.toISOString()) + ')';
   }
   if (obj === undefined) {
     return 'undefined';
   }
-  return JSON.stringify(obj)
+  return JSON.stringify(obj, undefined, indentation)
              .replace(/\u2028/g, '\\u2028')
              .replace(/\u2029/g, '\\u2029')
              .replace(/</g, '\\u003C')

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,9 @@ assert(stringify('foo') === '"foo"');
 assert(stringify('foo\u2028bar\u2029baz') === '"foo\\u2028bar\\u2029baz"');
 assert(stringify(new Date('2014-12-19T03:42:00.000Z')) === 'new Date("2014-12-19T03:42:00.000Z")');
 assert(stringify({foo: 'bar'}) === '{"foo":"bar"}');
+assert(stringify({foo: 'bar'}, undefined) === '{"foo":"bar"}');
+assert(stringify({foo: 'bar'}, 3) === '{\n   "foo": "bar"\n}');
+assert(stringify({foo: 'bar'}, '   \t') === '{\n   \t"foo": "bar"\n}');
 assert(stringify(undefined) === 'undefined');
 assert(stringify(null) === 'null');
 assert(


### PR DESCRIPTION
This patch allows emitting objects over multiple lines with indentation, for applications that might need it.  For example, a CLI tool might have a --pretty or --debug flag which generates more readable output.

It adds a second, optional argument to `stringify`.  It's passed as `JSON.stringify`'s third argument, which controls indentation.

```
stringify({foo: 'bar', baz: true});
/* {"foo":"bar","baz":true} */
stringify({foo: 'bar', baz: true}, '  ');
/* {
  "foo": "bar",
  "baz": true
}*/
stringify({foo: 'bar', baz: true}, 4);
/* {
    "foo": "bar",
    "baz": true
}*/
```